### PR TITLE
Fix for installation with homebrewed Qt on OS X (10.9)

### DIFF
--- a/lib/gks/plugin/qtplugin.cxx
+++ b/lib/gks/plugin/qtplugin.cxx
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <math.h>
 
-#include <Qt/qglobal.h>
+#include <QtCore/QtGlobal>
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QtWidgets/QWidget>
 #else

--- a/setup.py
+++ b/setup.py
@@ -529,7 +529,10 @@ int main()
             if not self.qmake:
                 self.qmake = Popen(["which", "qmake"],
                                stdout=PIPE).communicate()[0].decode().rstrip()
-            self.qtlibs = ["QtGui", "QtCore"]
+            if self.isDarwin:
+                self.qtlibs = []
+            else:
+                self.qtlibs = ["QtGui", "QtCore"]
         # -- x11 -------------------------------------
         if self.isLinux:
             x11ldflags = None


### PR DESCRIPTION
1) Replaced #include <Qt/qglobal.h> by #include <QtCore/QtGlobal>
For reference: https://github.com/LMMS/lmms/pull/840/files

2) Disabled the lQtgui and lQtCore flags, clang was failing with the following message:
ld: library not found for -lQtGui
clang: error: linker command failed with exit code 1 (use -v to see invocation)
