### PR TITLE
replace numpy fft with scipy fftpack in audio examples

### DIFF
--- a/examples/audio_ex.py
+++ b/examples/audio_ex.py
@@ -7,6 +7,8 @@ Play an audio file and display signal and power spectrum in realtime
 import os, wave, pyaudio
 import numpy
 import gr
+import scipy.fftpack
+
 
 SAMPLES = 2048
 
@@ -15,7 +17,7 @@ wf = wave.open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
 pa = pyaudio.PyAudio()
 stream = pa.open(format=pa.get_format_from_width(wf.getsampwidth()),
                  channels=wf.getnchannels(), rate=wf.getframerate(), output=True)
- 
+
 gr.setwindow(0, SAMPLES, -30000, 30000)
 gr.setviewport(0.05, 0.95, 0.05, 0.95)
 gr.setlinecolorind(218)
@@ -26,7 +28,7 @@ data = wf.readframes(SAMPLES)
 while data != '' and len(data) == SAMPLES * wf.getsampwidth():
     stream.write(data)
     amplitudes = numpy.fromstring(data, dtype=numpy.short)
-    power = abs(numpy.fft.fft(amplitudes / 512.0))[:SAMPLES/2:2] - 30000
+    power = abs(scipy.fftpack.fft(amplitudes / 512.0))[:SAMPLES/2:2] - 30000
 
     gr.clearws()
     gr.fillrect(0, SAMPLES, -30000, 30000)

--- a/examples/audio_ex3.py
+++ b/examples/audio_ex3.py
@@ -8,6 +8,7 @@ import os, wave, pyaudio
 import numpy as np
 import gr
 import gr3
+import scipy.fftpack
 
 FS=44100       # Sampling frequency
 SAMPLES = 2048
@@ -27,7 +28,7 @@ data = wf.readframes(SAMPLES)
 while data != '' and len(data) == SAMPLES * wf.getsampwidth():
     stream.write(data)
     amplitudes = np.fromstring(data, dtype=np.short)
-    power = abs(np.fft.fft(amplitudes / 32768.0))[:SAMPLES/2]
+    power = abs(scipy.fftpack.fft(amplitudes / 32768.0))[:SAMPLES/2]
 
     gr.clearws()
     spectrum[:, 63] = power[:256]

--- a/examples/qtgrspectrum.py
+++ b/examples/qtgrspectrum.py
@@ -12,6 +12,7 @@ import pyaudio
 import numpy
 from numpy import arange, sin, pi
 from scipy import signal
+import scipy.fftpack
 # local library
 import gr
 from gr.pygr import Plot, PlotAxes, PlotCurve
@@ -56,7 +57,7 @@ def get_spectrum():
         mic = pa.open(format=pyaudio.paInt16, channels=1, rate=FS,
                       input=True, frames_per_buffer=SAMPLES)
     amplitudes = numpy.fromstring(mic.read(SAMPLES), dtype=numpy.short)
-    return abs(numpy.fft.fft(amplitudes / 32768.0))[:SAMPLES/2]
+    return abs(scipy.fftpack.fft(amplitudes / 32768.0))[:SAMPLES/2]
 
 
 def parabolic(x, f, i):
@@ -175,4 +176,3 @@ def main(*args):
 
 if __name__ == "__main__":
     main(sys.argv)
-

--- a/examples/spectrum.py
+++ b/examples/spectrum.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import pyaudio
 import numpy
 from scipy import signal
+import scipy.fftpack
 import time
 import gr
 
@@ -23,7 +24,7 @@ def get_spectrum():
         mic = pa.open(format=pyaudio.paInt16, channels=1, rate=FS,
                       input=True, frames_per_buffer=SAMPLES)
     amplitudes = numpy.fromstring(mic.read(SAMPLES), dtype=numpy.short)
-    return abs(numpy.fft.fft(amplitudes / 32768.0))[:SAMPLES/2]
+    return abs(scipy.fftpack.fft(amplitudes / 32768.0))[:SAMPLES/2]
 
 def parabolic(x, f, i):
     xe = 1/2. * (f[i-1] - f[i+1]) / (f[i-1] - 2 * f[i] + f[i+1]) + x
@@ -64,4 +65,3 @@ while time.time() - start < 10:
             print(xe, ye)
             gr.polyline([xe] * 2, [0, ye])
     gr.updatews()
-

--- a/examples/spectrum3.py
+++ b/examples/spectrum3.py
@@ -6,6 +6,7 @@ Sample microphone input and display spectrogram
 
 import pyaudio
 import numpy as np
+import scipy.fftpack
 import time
 import gr
 import gr3
@@ -21,7 +22,7 @@ def get_spectrum():
         mic = pa.open(format=pyaudio.paInt16, channels=1, rate=FS,
                       input=True, frames_per_buffer=SAMPLES)
     amplitudes = np.fromstring(mic.read(SAMPLES), dtype=np.short)
-    return abs(np.fft.fft(amplitudes / 32768.0))[:SAMPLES/2]
+    return abs(scipy.fftpack.fft(amplitudes / 32768.0))[:SAMPLES/2]
 
 spectrum = np.zeros((256, 256), dtype=float)
 t = -255


### PR DESCRIPTION
One reason why the fftpack is almost twice as fast as the numpy implementation is that it checks if the input signal is real which always the case for audio data.

Since this is almost drop in replacement and you are using scipy in the project anyway, I would suggest making theses changes to speed up the realtime examples