### PR TITLE
Fix build error due to missing include in meta.c

### DIFF
--- a/lib/gr/meta.c
+++ b/lib/gr/meta.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #ifdef _WIN32
 #include <winsock2.h>
 #else


### PR DESCRIPTION
Building the python 2 version fails on Ubuntu 17.10 with the error:
```
lib/gr/meta.c: In function ‘argparse_calculate_needed_padding’:
lib/gr/meta.c:929:53: error: ‘uintptr_t’ undeclared (first use in this function)
     needed_padding = size_for_current_specifier - ((uintptr_t)buffer) % size_for_current_specifier;
                                                     ^~~~~~~~~
lib/gr/meta.c:929:53: note: each undeclared identifier is reported only once for each function it appears in
lib/gr/meta.c:929:63: error: expected ‘)’ before ‘buffer’
     needed_padding = size_for_current_specifier - ((uintptr_t)buffer) % size_for_current_specifier;
```
This can be fixed by adding the `stdint.h` include to `meta.c`.
After adding the include build is successful